### PR TITLE
Update ros2_alpha.repos

### DIFF
--- a/ros2_alpha.repos
+++ b/ros2_alpha.repos
@@ -486,7 +486,7 @@ repositories:
   box/hobot_sensor/hobot_mipi_cam:
     type: git
     url: https://github.com/HorizonRDK/hobot_mipi_cam.git
-    version: tros_2.1.2
+    version: tros_2.1.3
   box/hobot_sensor/hobot_imu_sensor:
     type: git
     url: https://github.com/HorizonRDK/hobot_imu_sensor.git


### PR DESCRIPTION
更新mipi_cam版本 2.1.3